### PR TITLE
Enable `preact-compat` to fix `recompose` in Zimlets.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zimbra/zimlet-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/entry.js
+++ b/src/entry.js
@@ -4,8 +4,8 @@
 ( () => {
 	function init() {
 		zimlet( context => {
-			let { zimbra, config, plugins, h, createElement, cloneElement, Component, components } = context;
-			global.preact = { h, createElement, cloneElement, Component };
+			let { zimbra, config, plugins, components, preact } = context;
+			global.preact = preact;
 			global.zimbra = zimbra;
 			global.config = config;
 			global.plugins = plugins;

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ export function configure(env) {
 
 			alias: {
 				preact: path.resolve(__dirname, 'preact.js'),
-				react: 'preact',
+				react: 'preact-compat',
 				'react-dom': 'preact-compat',
 				style: path.resolve(context, 'style'),
 				'zimlet-cli-entrypoint': path.resolve(context, entry)

--- a/src/preact.js
+++ b/src/preact.js
@@ -3,7 +3,7 @@
  *  Zimbra passed down when it called the factory provided to zimlet().
  */
 
-const { h, createElement, cloneElement, Component } = global.preact;
+const { h, createElement, cloneElement, Component, options } = global.preact;
 
-export { h, createElement, cloneElement, Component };
+export { h, createElement, cloneElement, Component, options };
 export default global.preact;


### PR DESCRIPTION
Alias `react: 'preact-compat'`. Pass through `preact.options` from global context in order to properly initialize `preact-compat`. This fixes `recompose` in zimlets, since `recompose` makes use of the `react.ceateFactory` export.

This requires a change on the application side, since we have to pass down `preact.options` we might as well pass the entire `preact` export down.
