### PR TITLE
PREAPPS-1329 : Adding graphQl related shims in fix-duplicate zimlet.

### DIFF
--- a/build-shims.js
+++ b/build-shims.js
@@ -24,7 +24,8 @@ mockery.registerMock('@zimbra-client/util', {
 	getDataTransferJSON: 1,
 	setDataTransferJSON: 1,
 	breakpoints: 1,
-	callWith: 1
+	callWith: 1,
+	pruneEmpty: 1
 });
 mockery.registerMock('@zimbra-client/util/contacts', {
 	getName: 1
@@ -39,7 +40,13 @@ mockery.registerMock('@zimbra-client/util/redux', {
 mockery.registerMock('@zimbra-client/graphql', {
 	CalendarsAndAppointmentsQuery: 1,
 	withCreateAppointment: 1,
-	withCalendars: 1
+	withCalendars: 1,
+	withSearch: 1,
+	withCreateContact: 1,
+	withModifyContact: 1,
+	withContactAction: 1,
+	withFilters: 1,
+	withModifyFilters: 1
 });
 mockery.registerMock('@zimbra-client/enhancers', {
 	withMediaQuery: 1

--- a/build-shims.js
+++ b/build-shims.js
@@ -43,10 +43,7 @@ mockery.registerMock('@zimbra-client/graphql', {
 	withCalendars: 1,
 	withSearch: 1,
 	withCreateContact: 1,
-	withModifyContact: 1,
-	withContactAction: 1,
-	withFilters: 1,
-	withModifyFilters: 1
+	withContactAction: 1
 });
 mockery.registerMock('@zimbra-client/enhancers', {
 	withMediaQuery: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zimbra/zimlet-cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -64,8 +64,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -86,14 +85,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -108,20 +105,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -238,8 +232,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -251,7 +244,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -266,7 +258,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -274,14 +265,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -300,7 +289,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -381,8 +369,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -394,7 +381,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -480,8 +466,7 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -517,7 +502,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -537,7 +521,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -581,14 +564,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6069,13 +6050,13 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -6138,8 +6119,7 @@
         "delayed-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "optional": true
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
           "version": "1.0.0",
@@ -6185,9 +6165,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -6280,8 +6260,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -6341,6 +6321,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -6427,16 +6408,14 @@
         "mime-db": {
           "version": "1.27.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "optional": true
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
         },
         "mime-types": {
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "optional": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -6715,6 +6694,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zimbra/zimlet-cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Develop, Build, and Package Zimbra X compatible zimlets for development and production.",
   "main": "dist/index.js",
   "bin": {

--- a/src/shims/@zimbra-client/graphql/index.js
+++ b/src/shims/@zimbra-client/graphql/index.js
@@ -10,4 +10,7 @@ const wrap = warnOnMissingExport.bind(null, global.shims['@zimbra-client/graphql
 export const CalendarsAndAppointmentsQuery = wrap('CalendarsAndAppointmentsQuery');
 export const withCreateAppointment = wrap('withCreateAppointment');
 export const withCalendars = wrap('withCalendars');
+export const withSearch = wrap('withSearch');
+export const withCreateContact = wrap('withCreateContact');
+export const withContactAction = wrap('withContactAction');
 export default global.shims['@zimbra-client/graphql'];

--- a/src/shims/@zimbra-client/util/index.js
+++ b/src/shims/@zimbra-client/util/index.js
@@ -12,4 +12,5 @@ export const getDataTransferJSON = wrap('getDataTransferJSON');
 export const setDataTransferJSON = wrap('setDataTransferJSON');
 export const breakpoints = wrap('breakpoints');
 export const callWith = wrap('callWith');
+export const pruneEmpty = wrap('pruneEmpty');
 export default global.shims['@zimbra-client/util'];


### PR DESCRIPTION
Fix-duplicate plugin needs to be migrated to be using graphQL API.
Some decorators needs to be shim to zimlet code.