### PR TITLE
ZX-1079: Add AttachmentItem shim.

### DIFF
--- a/build-shims.js
+++ b/build-shims.js
@@ -126,7 +126,8 @@ mockery.registerMock('@zimbra-client/components', {
 	TinyMceComposer: 1,
 	AddMore: 1,
 	FormGroup: 1,
-	AlignedLabel: 1
+	AlignedLabel: 1,
+	AttachmentItem: 1
 });
 
 mockery.registerMock('@zimbra-client/errors', {

--- a/src/shims/@zimbra-client/components/index.js
+++ b/src/shims/@zimbra-client/components/index.js
@@ -41,5 +41,6 @@ export const TinyMceComposer = wrap('TinyMceComposer');
 export const AddMore = wrap('AddMore');
 export const FormGroup = wrap('FormGroup');
 export const AlignedLabel = wrap('AlignedLabel');
+export const AttachmentItem = wrap('AttachmentItem');
 
 export default global.shims['@zimbra-client/components'];


### PR DESCRIPTION
To be used initially by the Dropbox Zimlet to show Dropbox shared links in the message body as attachment tiles.