### PR TITLE
ZX-1218 : Added NestedActionMenuItem to shims

### DIFF
--- a/build-shims.js
+++ b/build-shims.js
@@ -131,7 +131,8 @@ mockery.registerMock('@zimbra-client/components', {
 	AddMore: 1,
 	FormGroup: 1,
 	AlignedLabel: 1,
-	AttachmentItem: 1
+	AttachmentItem: 1,
+	NestedActionMenuItem: 1
 });
 
 mockery.registerMock('@zimbra-client/errors', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7884,10 +7884,16 @@
       "integrity": "sha512-mKW7Cdn68XMhdes0FjyIbA8+IVPsj3aIuAEQlZVkj9E2VhujWcXZEfwirBoXK6qZYfj1djaTBDCFKjAu1sK93w==",
       "dev": true
     },
+    "preact-context-provider": {
+      "version": "2.0.0-preactx.2",
+      "resolved": "https://registry.npmjs.org/preact-context-provider/-/preact-context-provider-2.0.0-preactx.2.tgz",
+      "integrity": "sha512-ltsYJtQ8QxrgTWvTzlIcCUsU2LYzi7Btg4DpTIEoV8Ktm9y4mGE4aceTyA7xdN2aHJY2fKXrDihG3b4G7to56g==",
+      "dev": true
+    },
     "preact-i18n": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/preact-i18n/-/preact-i18n-1.4.1.tgz",
-      "integrity": "sha512-FA0lVb3b3EVR1nJSglh/Bgg38ntRdp9VV1ewvpn46Pz7yuwOnJQBC8CddemmQjl9jdFCj5gUOgkJR8//9WZDSw==",
+      "version": "2.0.0-preactx.2",
+      "resolved": "https://registry.npmjs.org/preact-i18n/-/preact-i18n-2.0.0-preactx.2.tgz",
+      "integrity": "sha512-UEuiSajR+RHTaPneqqWMgC0dmT9R5IF+n8slNV5Uog533UGsncKaCeK1UyadlWKPKGHLaM5oZohGE9YF70xFnA==",
       "dev": true,
       "requires": {
         "dlv": "^1.1.2"
@@ -7903,9 +7909,8 @@
       }
     },
     "preact-router": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/preact-router/-/preact-router-3.1.0.tgz",
-      "integrity": "sha512-OeiSIl6C4ecfKl4wmEkkz5LO68PuNYuSWk1dxpjmTIMsXVRxm0PWw6PudAISQBjYmzMY9Z6NBfXoZjQDLV3l7g==",
+      "version": "github:zimbra/preact-router#98416c26daf3cd57bd98f1cd5ae091463224b902",
+      "from": "github:zimbra/preact-router#3.1.0_base_path_support",
       "dev": true
     },
     "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -58,9 +58,10 @@
     "mkdirp": "^0.5.1",
     "mockery": "^2.1.0",
     "preact": "^10.1.1",
-    "preact-i18n": "^1.4.1",
+    "preact-context-provider": "^2.0.0-preactx.2",
+    "preact-i18n": "^2.0.0-preactx.2",
     "preact-render-to-string": "^5.1.3",
-    "preact-router": "^3.1.0",
+    "preact-router": "github:zimbra/preact-router#3.1.0_base_path_support",
     "react-apollo": "^3.1.3",
     "react-redux": "^7.1.3",
     "rimraf": "^3.0.0"

--- a/src/shims/@zimbra-client/components/index.js
+++ b/src/shims/@zimbra-client/components/index.js
@@ -43,5 +43,6 @@ export const AddMore = wrap('AddMore');
 export const FormGroup = wrap('FormGroup');
 export const AlignedLabel = wrap('AlignedLabel');
 export const AttachmentItem = wrap('AttachmentItem');
+export const NestedActionMenuItem = wrap('NestedActionMenuItem');
 
 export default global.shims['@zimbra-client/components'];

--- a/src/shims/index.js
+++ b/src/shims/index.js
@@ -21,6 +21,7 @@ exports.SHIMMED_MODULES = [
 	'react-redux',
 	'react-apollo',
 	'graphql-tag',
+	'preact-context-provider',
 	'preact-pwa-install',
 	'preact-i18n',
 	'preact-render-to-string',

--- a/src/shims/preact-context-provider/index.js
+++ b/src/shims/preact-context-provider/index.js
@@ -1,0 +1,14 @@
+/** This file is an auto-generated shim, aliased in for "preact-context-provider" in the webpack config.
+*  When components import 'preact-context-provider', we want to give them back the copy
+*  Zimbra passed down when it called the factory provided to zimlet().
+*/
+
+/* eslint-disable camelcase, dot-notation */
+import { warnOnMissingExport } from '../';
+const wrap = warnOnMissingExport.bind(null, global.shims['preact-context-provider'], 'preact-context-provider');
+
+export const MergingProvider = wrap('MergingProvider');
+export default wrap('default');
+export const mergingProvide = wrap('mergingProvide');
+export const provide = wrap('provide');
+


### PR DESCRIPTION
This will make the NestedActionMenuItem component, needed for the Dropbox and OneDrive zimlets, available to these zimlets.

https://zimbra.atlassian.net/browse/ZX-1218

Associated PRs:
X Web: https://github.com/ZimbraOS/zm-x-web/pull/2241
Dropbox Zimlet: https://github.com/Zimbra/zm-x-zimlet-dropbox/pull/26
OneDrive Zimlet: https://github.com/Zimbra/zm-x-zimlet-onedrive/pull/10
OAuth Client: https://github.com/Zimbra/zm-x-oauth-client/pull/15