### PR TITLE
Update preact-i18n to newest preactx version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10154,9 +10154,9 @@
       "dev": true
     },
     "preact-i18n": {
-      "version": "2.0.0-preactx.2",
-      "resolved": "https://registry.npmjs.org/preact-i18n/-/preact-i18n-2.0.0-preactx.2.tgz",
-      "integrity": "sha512-UEuiSajR+RHTaPneqqWMgC0dmT9R5IF+n8slNV5Uog533UGsncKaCeK1UyadlWKPKGHLaM5oZohGE9YF70xFnA==",
+      "version": "2.3.0-preactx",
+      "resolved": "https://registry.npmjs.org/preact-i18n/-/preact-i18n-2.3.0-preactx.tgz",
+      "integrity": "sha512-0q23eJ92YVarzGgC1h5Yi1YPtupz4gmcPs9mrlhwNe/WHpF0dFqgr13FYrCJ8Cadv6R+/Ak4J8s+IO/3amqtGA==",
       "dev": true,
       "requires": {
         "dlv": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mockery": "^2.1.0",
     "preact": "^10.5.5",
     "preact-context-provider": "^2.0.0-preactx.2",
-    "preact-i18n": "^2.0.0-preactx.2",
+    "preact-i18n": "^2.3.0-preactx",
     "preact-render-to-string": "^5.1.11",
     "preact-router": "github:zimbra/preact-router#3.1.0_base_path_support",
     "react-redux": "^7.2.2",

--- a/src/shims/preact-i18n/index.js
+++ b/src/shims/preact-i18n/index.js
@@ -7,11 +7,14 @@
 import { warnOnMissingExport } from '../';
 const wrap = warnOnMissingExport.bind(null, global.shims['preact-i18n'], 'preact-i18n');
 
+export const IntlContext = wrap('IntlContext');
 export const IntlProvider = wrap('IntlProvider');
 export const Localizer = wrap('Localizer');
 export const MarkupText = wrap('MarkupText');
 export const Text = wrap('Text');
 export default wrap('default');
 export const intl = wrap('intl');
+export const translate = wrap('translate');
+export const useText = wrap('useText');
 export const withText = wrap('withText');
 


### PR DESCRIPTION
Includes new exports so we can use `useText` in zimlets.