### PR TITLE
ZX-1670: pass ZimletSlot to zimlets

### DIFF
--- a/build-shims.js
+++ b/build-shims.js
@@ -149,7 +149,8 @@ mockery.registerMock('@zimbra-client/components', {
 	ResponsiveModal: 1,
 	NestedActionMenuItem: 1,
 	PdfjsViewer: 1,
-	FolderListLight: 1
+	FolderListLight: 1,
+	ZimletSlot: 1
 });
 
 mockery.registerMock('@zimbra-client/errors', {

--- a/src/shims/@zimbra-client/components/index.js
+++ b/src/shims/@zimbra-client/components/index.js
@@ -47,5 +47,6 @@ export const ResponsiveModal = wrap('ResponsiveModal');
 export const NestedActionMenuItem = wrap('NestedActionMenuItem');
 export const PdfjsViewer = wrap('PdfjsViewer');
 export const FolderListLight = wrap('FolderListLight');
+export const ZimletSlot = wrap('ZimletSlot');
 
 export default global.shims['@zimbra-client/components'];


### PR DESCRIPTION
Passes ZimletSlot to zimlets, allowing a zimlet to create its own slot and load other zimlets into it.
(yes I know, zimletception. Be careful with the power!)

Refer to https://zimbra.atlassian.net/browse/ZX-1670 for integrated testing