### PR TITLE
PREAPPS-6373 : Fixing Server-SMIME availability scenarios.

### DIFF
--- a/build-shims.js
+++ b/build-shims.js
@@ -27,7 +27,8 @@ mockery.registerMock('@zimbra-client/util', {
 	pruneEmpty: 1,
 	PageVisibility: 1,
 	zimletEventEmitter: 1,
-	smimeHandler: 1
+	smimeHandler: 1,
+	isServerSMIMEFeatureAvailable: 1
 });
 
 mockery.registerMock('@zimbra-client/browser', {
@@ -196,7 +197,8 @@ mockery.registerMock('@zimbra-client/components', {
 	AddressField: 1,
 	Avatar: 1,
 	ContactHoverCardWrapper: 1,
-	CertificateModal: 1
+	CertificateModal: 1,
+	SMIMEOperationDropDown: 1
 });
 
 mockery.registerMock('@zimbra-client/errors', {

--- a/src/shims/@zimbra-client/components/index.js
+++ b/src/shims/@zimbra-client/components/index.js
@@ -54,5 +54,6 @@ export const AddressField = wrap('AddressField');
 export const Avatar = wrap('Avatar');
 export const ContactHoverCardWrapper = wrap('ContactHoverCardWrapper');
 export const CertificateModal = wrap('CertificateModal');
+export const SMIMEOperationDropDown = wrap('SMIMEOperationDropDown');
 
 export default global.shims['@zimbra-client/components'];

--- a/src/shims/@zimbra-client/util/index.js
+++ b/src/shims/@zimbra-client/util/index.js
@@ -16,5 +16,6 @@ export const pruneEmpty = wrap('pruneEmpty');
 export const PageVisibility = wrap('PageVisibility');
 export const zimletEventEmitter = wrap('zimletEventEmitter');
 export const smimeHandler = wrap('smimeHandler');
+export const isServerSMIMEFeatureAvailable = wrap('isServerSMIMEFeatureAvailable');
 
 export default global.shims['@zimbra-client/util'];


### PR DESCRIPTION
Fixing following scenarios:
1) User has valid SMIME license:
- If zimbraFeatureSMIMEEnabled is TRUE then Server-SMIME feature should be enabled.
- If zimbraFeatureSMIMEEnabled is FALSE then Server-SMIME feature should be disabled.
- If zimbraFeatureSMIMEEnabled is TRUE for COS then it should be enabled for all the users in that COS.
- If zimbraFeatureSMIMEEnabled is FALSE for COS then it should be disabled for all the users in that COS.
- If zimbraFeatureSMIMEEnabled is TRUE and Secure-Mail-Zimlet is enabled then Server-SMIME feature should be enabled.
- If zimbraFeatureSMIMEEnabled is TRUE and Secure-Mail-Zimlet is disabled then Server-SMIME feature should be disabled.
- If zimbraFeatureSMIMEEnabled is FALSE and Secure-Mail-Zimlet is enabled then Server-SMIME feature should be disabled.
- If zimbraFeatureSMIMEEnabled is FALSE and Secure-Mail-Zimlet is disabled then Server-SMIME feature should be disabled.

2) User doesn't have valid SMIME license:
- Server-SMIME should be disabled irrespective of zimbraFeatureSMIMEEnabled value.
- Server-SMIME should be disabled irrespective of availability of Secure-Mail-Zimlet.