### PR TITLE
PREAPPS-7601:  Modern UI mail recall end to end functionality

### DIFF
--- a/build-shims.js
+++ b/build-shims.js
@@ -104,6 +104,8 @@ mockery.registerMock('@zimbra-client/constants', {
 	PARTICIPATION_STATUS: 1,
 	supportedMimes: 1,
 	ZIMBRA_ZIMLET_EVENTS: 1,
+	USER_FOLDER_IDS: 1,
+	FLAGS: 1
 });
 
 mockery.registerMock('@zimbra-client/hooks', {

--- a/src/shims/@zimbra-client/constants/index.js
+++ b/src/shims/@zimbra-client/constants/index.js
@@ -11,5 +11,7 @@ export const ATTENDEE_ROLE = wrap('ATTENDEE_ROLE');
 export const PARTICIPATION_STATUS = wrap('PARTICIPATION_STATUS');
 export const supportedMimes = wrap('supportedMimes');
 export const ZIMBRA_ZIMLET_EVENTS = wrap('ZIMBRA_ZIMLET_EVENTS');
+export const USER_FOLDER_IDS = wrap('USER_FOLDER_IDS');
+export const FLAGS = wrap('FLAGS');
 
 export default global.shims['@zimbra-client/constants'];


### PR DESCRIPTION
Disable Mail recall option When recalling a message with users outside the user's domain (#189)
- Linking constants from zm-x-web to zm-modern-zimlets