### PR TITLE
PREAPPS-7580 Investigate Zimlets Loading Mechanism to safely Load JavaScript in Context

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 		'eslint-config-synacor'
 	],
 	globals: {
-		zimlet: true
+		getZimlet: true
 	},
 	rules: {
 		indent: ['error', 'tab', {

--- a/src/entry.js
+++ b/src/entry.js
@@ -1,40 +1,45 @@
 /** This is the real webpack entry file. It manages setting up the zimlet and HMR.
  *  The user-defined entry file (index.js) is imported here via a `zimlet-cli-entrypoint` alias.
  */
-( () => {
-	function init() {
-		zimlet( context => {
-			let { zimbra, config, plugins, shims, components, store, meta } = context;
+(() =>
+	getZimlet({
+		code: (() => {
+			function init() {
+				return (context) => {
+					let { zimbra, config, plugins, shims, components, store, meta } =
+						context;
 
-			// Add shims to the global scope to expose dependencies to Zimlets
-			// Shimmed dependencies include preact, preact-router, react-apollo
-			global.shims = shims;
+					// Add shims to the global scope to expose dependencies to Zimlets
+					// Shimmed dependencies include preact, preact-router, react-apollo
+					global.shims = shims;
 
-			global.zimbra = zimbra;
-			global.config = config;
-			global.plugins = plugins;
-			global.components = components;
-			global.store = store;
+					global.zimbra = zimbra;
+					global.config = config;
+					global.plugins = plugins;
+					global.components = components;
+					global.store = store;
 
-			global.ZIMLET_STYLES = [];
+					global.ZIMLET_STYLES = [];
 
-			global.meta = meta;
+					global.meta = meta;
 
-			let entry = require('zimlet-cli-entrypoint');
-			let r = entry && entry.default || entry;
+					let entry = require('zimlet-cli-entrypoint');
+					let r = (entry && entry.default) || entry;
 
-			// If export is a factory, pass it context. Otherwise it's a singleton.
-			let instance = typeof r==='function' ? r(context) : r;
+					// If export is a factory, pass it context. Otherwise it's a singleton.
+					let instance = typeof r === 'function' ? r(context) : r;
 
-			context.styles.set(global.ZIMLET_STYLES.join('\n'));
+					context.styles.set(global.ZIMLET_STYLES.join('\n'));
 
-			return instance;
-		});
-	}
+					return instance;
+				};
+			}
 
-	init();
+			if (process.env.NODE_ENV === 'development' && module.hot) {
+				module.hot.accept('zimlet-cli-entrypoint', init);
+			}
 
-	if (process.env.NODE_ENV==='development' && module.hot) {
-		module.hot.accept('zimlet-cli-entrypoint', init);
-	}
-})();
+			return init();
+		})(),
+		name: () => require('zimlet-cli-entrypoint-package').name
+	}))();

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,8 @@ export function configure(env) {
 				react: getShimPath('preact/compat'),
 				'react-dom': getShimPath('preact/compat'),
 				style: path.resolve(context, 'style'),
-				'zimlet-cli-entrypoint': path.resolve(context, entry)
+				'zimlet-cli-entrypoint': path.resolve(context, entry),
+				'zimlet-cli-entrypoint-package': path.resolve(context, path.resolve(cwd, 'package.json'))
 			}
 		},
 


### PR DESCRIPTION
The name function for zimlet identification has been updated in IIFE and pass the zimlet code and its name to the getZimlet function.

Important Note: This change requires rebuilding and redeploying existing zimlets due to the changes of zimlet building (in zimlet-cli)

Please review this for more clarity: https://github.com/Zimbra/zm-x-web/pull/5078