### PR TITLE
PREAPPS-7943: Implementation | Calendar reminder for important emails

### DIFF
--- a/build-shims.js
+++ b/build-shims.js
@@ -32,7 +32,8 @@ mockery.registerMock('@zimbra-client/util', {
 	startAttachmentDownloadProcess: 1,
 	htmlToText: 1,
 	clipboard: 1,
-	filterNonInsertableCalendars: 1
+	filterNonInsertableCalendars: 1,
+	closeEventTabThunk: 1
 });
 
 mockery.registerMock('@zimbra-client/browser', {
@@ -211,7 +212,9 @@ mockery.registerMock('@zimbra-client/components', {
 	SignatureBox: 1,
 	DeleteWrapper: 1,
 	CalendarOptionItem: 1,
-	HelpTooltip: 1
+	HelpTooltip: 1,
+	DateInput: 1,
+	CustomTimePicker: 1
 });
 
 mockery.registerMock('@zimbra-client/errors', {

--- a/src/shims/@zimbra-client/components/index.js
+++ b/src/shims/@zimbra-client/components/index.js
@@ -60,5 +60,7 @@ export const SignatureBox = wrap('SignatureBox');
 export const DeleteWrapper = wrap('DeleteWrapper');
 export const CalendarOptionItem = wrap('CalendarOptionItem');
 export const HelpTooltip = wrap('HelpTooltip');
+export const DateInput = wrap('DateInput');
+export const CustomTimePicker = wrap('CustomTimePicker');
 
 export default global.shims['@zimbra-client/components'];

--- a/src/shims/@zimbra-client/util/index.js
+++ b/src/shims/@zimbra-client/util/index.js
@@ -21,5 +21,6 @@ export const startAttachmentDownloadProcess = wrap('startAttachmentDownloadProce
 export const htmlToText = wrap('htmlToText');
 export const clipboard = wrap('clipboard');
 export const filterNonInsertableCalendars = wrap('filterNonInsertableCalendars');
+export const closeEventTabThunk = wrap('closeEventTabThunk');
 
 export default global.shims['@zimbra-client/util'];


### PR DESCRIPTION
- Added closeEventTabThunk, CreateAppointmentMutation, DateInput, CustomTimePicker in build-shim.js file to use them in zimbra-zimlet-email-reminder zimlet

**Related PR:**

- [zm-x-web](https://github.com/Zimbra/zm-x-web/pull/5144)
- [zm-api-js-client](https://github.com/Zimbra/zm-api-js-client/pull/709)
- [zm-modern-zimlets](https://github.com/Zimbra/zm-modern-zimlets/pull/420) 