### PR TITLE
PREAPPS-9222: Fix CircleCI workflow to prevent zimlet build failures (might be run time failure) caused by overriding zimlet-cli versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,14 @@ feature-branch: &feature-branch
   filters:
     branches:
       ignore:
+        - master
         - /(custom_)?release\/.*/
+
+master-branch: &master-branch
+  filters:
+    branches:
+      only:
+        - master
 
 ############################################################################
 # COMMANDS
@@ -141,9 +148,11 @@ workflows:
 
   commit-workflow:
     jobs:
-      - prepare-npm-deps
+      - prepare-npm-deps:
+          <<: *feature-branch
 
       - test:
+          <<: *feature-branch
           requires:
             - prepare-npm-deps
 
@@ -158,5 +167,15 @@ workflows:
           <<: *env-context
           requires:
             - publish-approval
+
+  master-branch-workflow:
+    jobs:
+      - prepare-npm-deps:
+          <<: *master-branch
+
+      - test:
+          <<: *master-branch
+          requires:
+            - prepare-npm-deps
 
 ################################################


### PR DESCRIPTION
- Removed publish job from Master branch workflow. Consumer project (zm-modern-zimlets) doesn't consider the master branch changes to build the zimlet instead of that it use the zimlet-cli version that has been defined in the package.json file of the zimlet.